### PR TITLE
Update partial loader to use eager imports

### DIFF
--- a/frontend/assets/js/utils/partial-loader.js
+++ b/frontend/assets/js/utils/partial-loader.js
@@ -2,19 +2,20 @@ export async function loadPartials() {
   const elements = document.querySelectorAll('[data-include]');
   if (elements.length === 0) return;
 
-  const modules = import.meta.glob('/partials/**/*.html', { query: '?raw' });
-  await Promise.all(
-    Array.from(elements).map(async el => {
-      const path = el.getAttribute('data-include');
-      if (modules[path]) {
-        const m = await modules[path]();
-        el.innerHTML = m.default;
-        el.removeAttribute('data-include');
-      } else {
-        console.error('Partial not found:', path);
-      }
-    })
-  );
+  const modules = import.meta.glob('/partials/**/*.html', {
+    eager: true,
+    query: '?raw'
+  });
+
+  Array.from(elements).forEach(el => {
+    const path = el.getAttribute('data-include');
+    if (modules[path]) {
+      el.innerHTML = modules[path].default;
+      el.removeAttribute('data-include');
+    } else {
+      console.error('Partial not found:', path);
+    }
+  });
 
   if (document.querySelectorAll('[data-include]').length > 0) {
     await loadPartials();


### PR DESCRIPTION
## Summary
- use `import.meta.glob` eagerly in partial loader
- set partial HTML directly instead of waiting on imports

## Testing
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_688ba77b26cc8331a45d2f52d3c6f955