### PR TITLE
Add icon loading skeleton

### DIFF
--- a/frontend/assets/css/components/_icons.css
+++ b/frontend/assets/css/components/_icons.css
@@ -1,0 +1,8 @@
+/* icons.css - styles for lazy loaded icon placeholders */
+
+@layer components {
+  .icon-placeholder {
+    @apply bg-gray-200 animate-pulse rounded block w-full h-full;
+  }
+}
+

--- a/frontend/assets/css/main.css
+++ b/frontend/assets/css/main.css
@@ -15,6 +15,7 @@
 @import "./components/_cards.css";
 @import "./components/_buttons.css";
 @import "./components/_notifications.css";
+@import "./components/_icons.css";
 
 /* ۴. وارد کردن استایل‌های مخصوص صفحات */
 @import "./pages/_login.css";

--- a/frontend/assets/js/components/icon-loader.js
+++ b/frontend/assets/js/components/icon-loader.js
@@ -1,19 +1,29 @@
 // assets/js/components/icon-loader.js
 export function loadIcons() {
-  document.querySelectorAll('i-con:not([data-loaded="true"])').forEach(async (iconElement) => {
-    iconElement.dataset.loaded = 'true';
+  document.querySelectorAll('i-con:not([data-loaded])').forEach(async (iconElement) => {
     const iconName = iconElement.getAttribute('name') || iconElement.getAttribute('data-icon');
     if (!iconName) return;
+
+    iconElement.dataset.loaded = 'loading';
+
+    const placeholder = document.createElement('span');
+    placeholder.className = 'icon-placeholder';
+    iconElement.innerHTML = '';
+    iconElement.appendChild(placeholder);
+
     try {
       if (iconName.toLowerCase().endsWith('.png')) {
-        const img = document.createElement('img');
+        const img = new Image();
         img.src = `/assets/icons/${iconName}`;
         img.alt = iconElement.getAttribute('alt') || iconName.replace('.png', '');
         img.setAttribute('aria-hidden', 'true');
         img.setAttribute('role', 'img');
-        img.className = 'w-full h-full object-contain';
-        iconElement.innerHTML = '';
-        iconElement.appendChild(img);
+        img.className = 'w-full h-full object-contain opacity-0 transition-opacity duration-300';
+        img.onload = () => {
+          placeholder.replaceWith(img);
+          requestAnimationFrame(() => img.classList.remove('opacity-0'));
+          iconElement.dataset.loaded = 'true';
+        };
       } else {
         const response = await fetch(`/assets/icons/${iconName}.svg`);
         if (!response.ok) throw new Error(`Icon not found: ${iconName}`);
@@ -23,13 +33,15 @@ export function loadIcons() {
         const svgNode = svgDoc.documentElement;
         svgNode.setAttribute('aria-hidden', 'true');
         svgNode.setAttribute('role', 'img');
-        svgNode.setAttribute('class', 'w-full h-full');
-        iconElement.innerHTML = '';
-        iconElement.appendChild(svgNode);
+        svgNode.setAttribute('class', 'w-full h-full opacity-0 transition-opacity duration-300');
+        placeholder.replaceWith(svgNode);
+        requestAnimationFrame(() => svgNode.classList.remove('opacity-0'));
+        iconElement.dataset.loaded = 'true';
       }
     } catch (error) {
       console.error('Error loading icon:', error);
       iconElement.innerHTML = '';
+      iconElement.dataset.loaded = 'error';
     }
   });
 }


### PR DESCRIPTION
## Summary
- support icon placeholders with new `.icon-placeholder` class
- fade in icons when loaded via `icon-loader.js`
- import icon styles in `main.css`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ba9205364833186658a9bfcb3173c