### PR TITLE
Add delay config for icon skeletons

### DIFF
--- a/frontend/assets/js/components/icon-loader.js
+++ b/frontend/assets/js/components/icon-loader.js
@@ -1,17 +1,57 @@
 // assets/js/components/icon-loader.js
+// تنظیمات افکت اسکلتون آیکن‌ها
+export const iconLoaderConfig = {
+  // برای غیرفعال کردن اسکلتون می‌توانید مقدار این متغیر را false قرار دهید
+  enabled: true,
+  // تاخیر نمایش آیکن بعد از لود شدن (بر حسب میلی ثانیه)
+  delay: 0,
+};
+
+// اگر مقادیر در window تعریف شده باشد، آن‌ها را جایگزین می‌کنیم
+if (typeof window !== 'undefined') {
+  if (window.iconSkeletonEnabled !== undefined) {
+    iconLoaderConfig.enabled = window.iconSkeletonEnabled;
+  }
+  if (window.iconSkeletonDelay !== undefined) {
+    iconLoaderConfig.delay = window.iconSkeletonDelay;
+  }
+}
+
 export function loadIcons() {
   document.querySelectorAll('i-con:not([data-loaded])').forEach(async (iconElement) => {
     const iconName = iconElement.getAttribute('name') || iconElement.getAttribute('data-icon');
     if (!iconName) return;
 
-    iconElement.dataset.loaded = 'loading';
+    iconElement.dataset.loaded = iconLoaderConfig.enabled ? 'loading' : 'pending';
 
-    const placeholder = document.createElement('span');
-    placeholder.className = 'icon-placeholder';
-    iconElement.innerHTML = '';
-    iconElement.appendChild(placeholder);
+    let placeholder;
+    if (iconLoaderConfig.enabled) {
+      placeholder = document.createElement('span');
+      placeholder.className = 'icon-placeholder';
+      iconElement.innerHTML = '';
+      iconElement.appendChild(placeholder);
+    } else {
+      iconElement.innerHTML = '';
+    }
 
     try {
+      const replaceIcon = (node) => {
+        const action = () => {
+          if (iconLoaderConfig.enabled) {
+            placeholder.replaceWith(node);
+          } else {
+            iconElement.appendChild(node);
+          }
+          requestAnimationFrame(() => node.classList.remove('opacity-0'));
+          iconElement.dataset.loaded = 'true';
+        };
+        if (iconLoaderConfig.enabled && iconLoaderConfig.delay > 0) {
+          setTimeout(action, iconLoaderConfig.delay);
+        } else {
+          action();
+        }
+      };
+
       if (iconName.toLowerCase().endsWith('.png')) {
         const img = new Image();
         img.src = `/assets/icons/${iconName}`;
@@ -19,11 +59,7 @@ export function loadIcons() {
         img.setAttribute('aria-hidden', 'true');
         img.setAttribute('role', 'img');
         img.className = 'w-full h-full object-contain opacity-0 transition-opacity duration-300';
-        img.onload = () => {
-          placeholder.replaceWith(img);
-          requestAnimationFrame(() => img.classList.remove('opacity-0'));
-          iconElement.dataset.loaded = 'true';
-        };
+        img.onload = () => replaceIcon(img);
       } else {
         const response = await fetch(`/assets/icons/${iconName}.svg`);
         if (!response.ok) throw new Error(`Icon not found: ${iconName}`);
@@ -34,9 +70,7 @@ export function loadIcons() {
         svgNode.setAttribute('aria-hidden', 'true');
         svgNode.setAttribute('role', 'img');
         svgNode.setAttribute('class', 'w-full h-full opacity-0 transition-opacity duration-300');
-        placeholder.replaceWith(svgNode);
-        requestAnimationFrame(() => svgNode.classList.remove('opacity-0'));
-        iconElement.dataset.loaded = 'true';
+        replaceIcon(svgNode);
       }
     } catch (error) {
       console.error('Error loading icon:', error);


### PR DESCRIPTION
## Summary
- enable configuring icon skeleton loading via `iconLoaderConfig`
- allow disabling skeleton effect and adding a delay before the icon appears

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688bddc9c06c8331ba0072c823d119fb